### PR TITLE
Support files with space in the name

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -23,7 +23,7 @@ local function setup(args)
   end
 
   if args.trash_list_selector == nil then
-    args.trash_list_selector = "fzf -m | awk '{print $3}'"
+    args.trash_list_selector = "fzf -m | cut -d' ' -f3-"
   end
 
   -- Trash: delete
@@ -53,16 +53,15 @@ local function setup(args)
     messages = {
       {
         BashExec = [===[
-        files="$(trash-list | ]===] .. args.trash_list_selector .. [===[)"
-
-        echo -e "$files" | while IFS= read -r line; do
-          if ([ -n "$line" ] && yes 0 | trash-restore -- "$line" > /dev/null); then
-            echo FocusPath: '"'$line'"' >> "${XPLR_PIPE_MSG_IN:?}"
-            echo LogSuccess: "Restored $line" >> "${XPLR_PIPE_MSG_IN:?}"
-          else
-            echo LogError: "Failed to restore $line" >> "${XPLR_PIPE_MSG_IN:?}"
-          fi
-        done
+        trash-list | ]===] .. args.trash_list_selector .. [===[ |
+          while IFS= read -r line; do
+            if ([ -n "$line" ] && yes 0 | trash-restore -- "$line" > /dev/null); then
+              echo FocusPath: '"'$line'"' >> "${XPLR_PIPE_MSG_IN:?}"
+              echo LogSuccess: "Restored $line" >> "${XPLR_PIPE_MSG_IN:?}"
+            else
+              echo LogError: "Failed to restore $line" >> "${XPLR_PIPE_MSG_IN:?}"
+            fi
+          done
 
         echo ExplorePwdAsync >> "${XPLR_PIPE_MSG_IN:?}"
         ]===]


### PR DESCRIPTION
`awk` would print only third column, so it would cut off file path after the first encountered space. With `cut` it's easier 🙂 

Also removed the variable and just passing things directly. Reviewing this PR with `?w=0` appended to the URL might be easier 🙂 

Btw, have not found an example where `[ -n "$line" ]` check would be useful, but didn't remove it just in case.

Nice to see the plugins ecosystem!

Btw I saw in your dotfiles you had to organize your private plugins in this exact layout, with `src` subdir for example. Personally I found it a bit easier to just re-declare `package.path` [like so](https://github.com/maximbaz/dotfiles/commit/f711f9350d3649817c9253132ea8abda48c8dbfb), no need to have all too many nested folders in dotfiles 😉 

Finally, what do you think about having a "force delete" action in this plugin, one that runs `rm -rf` instead of `trash-put`? If you think it belongs here I can send a PR, if not I'll keep it in my config.
